### PR TITLE
Add README and script annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# Motion Capture Processing Pipeline
+
+This repository contains a step-by-step pipeline for cleaning and analysing
+marker based motion capture recordings. Raw CSV exports are transformed through
+a series of scripts into averaged trajectories and final plots.
+
+## Directory structure
+
+- `Exports/`
+  - `Probant*/` – raw recordings grouped by participant (`Probant`) and
+    experiment.
+  - `Daten_Raw/` – copy of all raw CSV files organised by experiment.
+  - `Daten_Raw_Formatted/` – output of **Step1**, raw data converted to
+    semicolon-separated CSV files with uniform columns.
+  - `Daten_Raw_Clean/` – output of **Step2**, cleaned marker positions.
+  - `Reference/` – reference recordings for markers 4 and 5 used during
+    interpolation.
+  - `Daten_Raw_Interpolated/` – output of **Step3**, files where internal gaps
+    are interpolated and missing head/tail segments are filled from reference
+    data.
+  - `Daten_Trimmed/` – output of **Step4**, recordings truncated once movement
+    stops.
+  - `Daten_Averaged_1M/` – output of **Step5**, averages across repeated trials
+    for a single probant and experiment.
+  - `Final_Averages_1M/` – output of **Step6**, averages across probants for each
+    experiment.
+  - `Final_Cleaned/` – output of **Step7**, smoothed trajectories.
+  - `Plots/` – output of **Step8**, velocity and acceleration plots.
+  - `Clustered/` – output of **Step9**, aggregated data by demographic clusters.
+
+## Processing steps
+
+1. **Step1_csv_formatter.py** – normalize raw CSV files and switch delimiters.
+2. **Step2_data_clean_recursive.py** – parse marker columns and replace missing
+   base marker values with temporary ones.
+3. **Step2-5_references.py** – select best reference recordings for markers 4
+   and 5.
+4. **Step3_interpolate.py** – interpolate internal gaps and use reference data
+   for remaining segments.
+5. **Step4_trim.py** – remove trailing frames after motion has ceased.
+6. **Step5_average_1M.py** – average multiple trials per probant and experiment.
+7. **Step6_average_by_experiment_1M.py** – average probant means for each
+   experiment.
+8. **Step7_clean_final_data.py** – apply Savitzky–Golay smoothing to averaged
+   trajectories.
+9. **Step8_plots.py** – generate velocity and acceleration plots for the final
+   trajectories.
+10. **Step9_Segmentation.py** – aggregate results into demographic clusters and
+    produce summary plots.
+
+Additional utilities:
+
+- **data_clean_v1.py** – early prototype of the cleaning procedure.
+- **visualize_marker_trajectories.py** – render 3D animations of marker
+  trajectories from a processed CSV file.
+
+## Usage
+
+Each step expects the output of the previous step to exist in the `Exports`
+folder. Run scripts in numerical order to reproduce the full pipeline:
+
+```bash
+python Step1_csv_formatter.py
+python Step2_data_clean_recursive.py
+python Step2-5_references.py
+python Step3_interpolate.py
+python Step4_trim.py
+python Step5_average_1M.py
+python Step6_average_by_experiment_1M.py
+python Step7_clean_final_data.py
+python Step8_plots.py
+python Step9_Segmentation.py
+```
+
+The optional `visualize_marker_trajectories.py` can be used on any processed CSV
+file to inspect marker paths in three dimensions.

--- a/Step1_csv_formatter.py
+++ b/Step1_csv_formatter.py
@@ -1,3 +1,12 @@
+"""Convert raw CSV files to a normalized format.
+
+This script walks through the ``Exports/Daten_Raw`` tree and rewrites each
+CSV file so that all rows have the same number of columns and the delimiter is
+switched from a comma to a semicolon. The result is stored in
+``Exports/Daten_Raw_Formatted`` and serves as the starting point for the later
+cleaning steps.
+"""
+
 import os
 import csv
 
@@ -8,7 +17,15 @@ output_root = "Exports/Daten_Raw_Formatted"
 # --- Ensure output root exists ---
 os.makedirs(output_root, exist_ok=True)
 
-def clean_and_convert_file(input_path, output_path):
+
+def clean_and_convert_file(input_path: str, output_path: str) -> None:
+    """Normalize a single CSV file.
+
+    The raw export uses commas as separators and can have varying numbers of
+    columns per row. This function pads missing columns, replaces the delimiter
+    with semicolons and writes the cleaned file to ``output_path``.
+    """
+
     try:
         with open(input_path, "r", encoding="cp1252") as f:
             lines = [line.strip() for line in f if line.strip()]

--- a/Step2-5_references.py
+++ b/Step2-5_references.py
@@ -1,3 +1,5 @@
+"""Select the best reference files for markers 4 and 5 per experiment type."""
+
 import os
 import pandas as pd
 

--- a/Step5_average_1M.py
+++ b/Step5_average_1M.py
@@ -1,3 +1,5 @@
+"""Average multiple recordings of the same probant and experiment."""
+
 import os
 import pandas as pd
 import numpy as np
@@ -15,7 +17,9 @@ NORMALIZE_START = True
 EXPERIMENTS = ["kreis", "ptp", "ptp2", "ptp3", "zikzak", "sequentiell"]
 
 # --- Utility Functions ---
-def normalize_start(df):
+def normalize_start(df: pd.DataFrame) -> pd.DataFrame:
+    """Shift trajectories so that each marker starts at the origin."""
+
     for marker in MARKERS:
         for axis in AXES:
             col = f"{marker}_{axis}"
@@ -23,7 +27,9 @@ def normalize_start(df):
                 df[col] -= df[col].iloc[0]
     return df
 
-def resample_df(df, target_len):
+def resample_df(df: pd.DataFrame, target_len: int) -> pd.DataFrame:
+    """Linearly resample each column to ``target_len`` rows."""
+
     def safe_interp(col):
         col = col.astype(float)
         if col.isna().all():
@@ -31,11 +37,14 @@ def resample_df(df, target_len):
         return np.interp(
             np.linspace(0, len(col) - 1, target_len),
             np.arange(len(col)),
-            col
+            col,
         )
+
     return df.apply(safe_interp)
 
-def get_probant_and_experiment(filename):
+def get_probant_and_experiment(filename: str):
+    """Extract probant and experiment name from ``filename``."""
+
     name = os.path.basename(filename).lower()
     match = re.search(r"probant\d+", name)
     probant = match.group(0) if match else None

--- a/Step6_average_by_experiment_1M.py
+++ b/Step6_average_by_experiment_1M.py
@@ -1,3 +1,5 @@
+"""Average previously averaged trajectories across probants for each experiment."""
+
 import os
 import pandas as pd
 import numpy as np
@@ -11,7 +13,9 @@ DELIMITER = ";"
 EXPERIMENTS = ["kreis", "ptp", "ptp2", "ptp3", "zikzak", "sequentiell"]
 
 # --- Helper: interpolate each column to target length ---
-def resample_df(df, target_len):
+def resample_df(df: pd.DataFrame, target_len: int) -> pd.DataFrame:
+    """Resample each column to ``target_len`` using linear interpolation."""
+
     def safe_interp(col):
         col = col.astype(float)
         if col.isna().all():
@@ -19,8 +23,9 @@ def resample_df(df, target_len):
         return np.interp(
             np.linspace(0, len(col) - 1, target_len),
             np.arange(len(col)),
-            col
+            col,
         )
+
     return df.apply(safe_interp)
 
 # --- Group all *_mean.csv by experiment ---

--- a/Step7_clean_final_data.py
+++ b/Step7_clean_final_data.py
@@ -1,3 +1,5 @@
+"""Apply Savitzky–Golay smoothing to final averaged trajectories."""
+
 import os
 import pandas as pd
 import numpy as np

--- a/Step8_plots.py
+++ b/Step8_plots.py
@@ -1,3 +1,5 @@
+"""Plot scalar velocity and acceleration for each marker."""
+
 import os
 import pandas as pd
 import numpy as np
@@ -16,8 +18,9 @@ AXES = ["X", "Y", "Z"]
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 files = glob(f"{INPUT_DIR}/*_final_clean.csv")
 
-def compute_scalar_velocity_and_acceleration(df, marker_id):
-    # Compute v = ||(vx, vy, vz)|| and a = ||(ax, ay, az)|| for a given marker
+def compute_scalar_velocity_and_acceleration(df: pd.DataFrame, marker_id: int):
+    """Return smoothed velocity and acceleration magnitudes for ``marker_id``."""
+
     vs = []
     accs = []
     for axis in AXES:
@@ -29,8 +32,8 @@ def compute_scalar_velocity_and_acceleration(df, marker_id):
             vs.append(v)
             accs.append(a)
     if len(vs) == 3:
-        vel_norm = np.sqrt(vs[0]**2 + vs[1]**2 + vs[2]**2)
-        acc_norm = np.sqrt(accs[0]**2 + accs[1]**2 + accs[2]**2)
+        vel_norm = np.sqrt(vs[0] ** 2 + vs[1] ** 2 + vs[2] ** 2)
+        acc_norm = np.sqrt(accs[0] ** 2 + accs[1] ** 2 + accs[2] ** 2)
 
         # Smooth the results using Savitzky-Golay filter
         window_v = 9 if len(vel_norm) >= 9 else len(vel_norm) // 2 * 2 + 1

--- a/Step9_Segmentation.py
+++ b/Step9_Segmentation.py
@@ -1,3 +1,5 @@
+"""Cluster averaged data by demographic groups and plot aggregated curves."""
+
 import os
 import pandas as pd
 import numpy as np
@@ -49,15 +51,19 @@ probanten_dict = {
     37: {'Alter': '21-25', 'Geschlecht': 'Männlich'},
 }
 
-def get_meta(probant_str):
+def get_meta(probant_str: str):
+    """Return gender and age group for a given probant string."""
+
     try:
         num = int(probant_str.replace("probant", ""))
         meta = probanten_dict.get(num, {'Alter': '21-25', 'Geschlecht': 'Männlich'})
         return meta['Geschlecht'], meta['Alter']
-    except:
+    except:  # noqa: E722 - fallback is fine here
         return 'Männlich', '21-25'
 
-def resample_df(df, target_len):
+def resample_df(df: pd.DataFrame, target_len: int) -> pd.DataFrame:
+    """Resample ``df`` to ``target_len`` rows using linear interpolation."""
+
     df_interp = {}
     for col in df.columns:
         if col == "Frame":
@@ -72,11 +78,13 @@ def resample_df(df, target_len):
         df_interp[col] = y_new
     return pd.DataFrame(df_interp)
 
-def plot_derivatives_scalar_style(df, out_dir, markers=MARKERS, axes=AXES):
+def plot_derivatives_scalar_style(df: pd.DataFrame, out_dir: str, markers=MARKERS, axes=AXES):
+    """Plot velocity/acceleration magnitudes for ``df`` and store a PNG."""
+
     frame = df["Frame"].values
 
     from scipy.ndimage import median_filter
-    
+
     def compute_scalar(df, marker_id):
         vs, accs = [], []
         for axis in AXES:
@@ -89,8 +97,8 @@ def plot_derivatives_scalar_style(df, out_dir, markers=MARKERS, axes=AXES):
                 accs.append(a)
 
         if len(vs) == 3:
-            vel = np.sqrt(vs[0]**2 + vs[1]**2 + vs[2]**2)
-            acc = np.sqrt(accs[0]**2 + accs[1]**2 + accs[2]**2)
+            vel = np.sqrt(vs[0] ** 2 + vs[1] ** 2 + vs[2] ** 2)
+            acc = np.sqrt(accs[0] ** 2 + accs[1] ** 2 + accs[2] ** 2)
 
             # --- Glättung & Spike-Entfernung für Geschwindigkeit ---
             win_v = 11 if len(vel) >= 11 else len(vel) // 2 * 2 + 1
@@ -135,7 +143,9 @@ def plot_derivatives_scalar_style(df, out_dir, markers=MARKERS, axes=AXES):
     plt.savefig(os.path.join(out_dir, "velocity_acc_scalar.png"))
     plt.close()
 
-def save_cluster_average(mode, cluster_key, experiment, dfs):
+def save_cluster_average(mode: str, cluster_key: str, experiment: str, dfs: list):
+    """Average all ``dfs`` and store results and plots in the cluster folder."""
+
     if len(dfs) < 2:
         print(f"⚠️ Not enough data for {mode}/{cluster_key} - {experiment}")
         return

--- a/data_clean_v1.py
+++ b/data_clean_v1.py
@@ -1,3 +1,5 @@
+"""Prototype script for cleaning a single CSV file."""
+
 import pandas as pd
 import numpy as np
 import re

--- a/visualize_marker_trajectories.py
+++ b/visualize_marker_trajectories.py
@@ -1,3 +1,5 @@
+"""Visualise 3D marker trajectories from a processed CSV file."""
+
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## Summary
- Document repository structure and processing pipeline in new README
- Add module and function docstrings across all processing scripts

## Testing
- `python -m py_compile Step1_csv_formatter.py Step2_data_clean_recursive.py Step2-5_references.py Step3_interpolate.py Step4_trim.py Step5_average_1M.py Step6_average_by_experiment_1M.py Step7_clean_final_data.py Step8_plots.py Step9_Segmentation.py data_clean_v1.py visualize_marker_trajectories.py`


------
https://chatgpt.com/codex/tasks/task_e_68b410a631e48323bd7e6c031444759d